### PR TITLE
fix: postprocessor collection initialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-ssr",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Angular server-side rendering implementation",
   "main": "build/index.js",
   "typings": "build/index.d.ts",

--- a/source/application/builder/builder-base.ts
+++ b/source/application/builder/builder-base.ts
@@ -42,6 +42,9 @@ export abstract class ApplicationBuilderBase<V> implements ApplicationBuilder<V>
 
   postprocess(transform?: Postprocessor) {
     if (transform) {
+      if (this.operation.postprocessors == null) {
+        this.operation.postprocessors = [];
+      }
       this.operation.postprocessors.push(transform);
     }
     return this.operation.postprocessors;


### PR DESCRIPTION
When adding postprocessors to the builder, we are getting the following error:

`Cannot read property 'push' of undefined`

It looks like the collection is not being initialized. This should fix that.